### PR TITLE
Remove unnecessary spaces on empty lines

### DIFF
--- a/remove-widget-titles.php
+++ b/remove-widget-titles.php
@@ -7,8 +7,8 @@ Version: 1.0
 Date: 23 November 2011
 Author: Stephen Cronin
 Author URI: http://www.scratch99.com/
-   
-   Copyright 2011 Stephen Cronin (email: sjc@scratch99.com)
+
+    Copyright 2011 Stephen Cronin (email: sjc@scratch99.com)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Empty lines with spaces are highlighted in nano on linux, and are unnecessary.